### PR TITLE
Fix import chain and matrix multiply

### DIFF
--- a/hyperflowx/__init__.py
+++ b/hyperflowx/__init__.py
@@ -1,11 +1,31 @@
 # hyperflowx/__init__.py
 
 from .sorting import hybrid_sort
-from .ml_model import train_hyperflowx
-from .optimizations import fast_matrix_mult
-from .pipeline import async_pipeline
-from .security import pascal_diamond_hash  # ✅ Added missing import
-from .ai_automation import automate_hyperflowx_fixes  # ✅ Added AI-powered automation
+from .ai_automation import automate_hyperflowx_fixes
+
+
+def train_hyperflowx(*args, **kwargs):
+    """Lazily import and invoke :func:`ml_model.train_hyperflowx`."""
+    from .ml_model import train_hyperflowx as _train
+    return _train(*args, **kwargs)
+
+
+def fast_matrix_mult(*args, **kwargs):
+    """Lazily import and invoke :func:`optimizations.fast_matrix_mult`."""
+    from .optimizations import fast_matrix_mult as _fast
+    return _fast(*args, **kwargs)
+
+
+def async_pipeline(*args, **kwargs):
+    """Lazily import and invoke :func:`pipeline.async_pipeline`."""
+    from .pipeline import async_pipeline as _pipeline
+    return _pipeline(*args, **kwargs)
+
+
+def pascal_diamond_hash(*args, **kwargs):
+    """Lazily import and invoke :func:`security.pascal_diamond_hash`."""
+    from .security import pascal_diamond_hash as _hash
+    return _hash(*args, **kwargs)
 
 __all__ = [
     "hybrid_sort",

--- a/hyperflowx/optimizations.py
+++ b/hyperflowx/optimizations.py
@@ -4,5 +4,13 @@ import numba
 # 🚀 Optimized Parallel Matrix Multiplication (SIMD-Accelerated)
 @numba.njit(parallel=True, fastmath=True)
 def fast_matrix_mult(A, B):
-    """Performs fast parallel matrix multiplication using NumPy dot product (SIMD-accelerated)."""
-    return np.dot(A, B)  # ✅ Uses NumPy’s highly optimized BLAS backend
+    """Perform fast matrix multiplication without requiring SciPy."""
+    n, m = A.shape[0], B.shape[1]
+    result = np.zeros((n, m))
+    for i in numba.prange(n):
+        for j in range(m):
+            acc = 0.0
+            for k in range(A.shape[1]):
+                acc += A[i, k] * B[k, j]
+            result[i, j] = acc
+    return result


### PR DESCRIPTION
## Summary
- avoid heavy optional dependencies on import
- reimplement fast matrix multiply to remove SciPy requirement
- update tests to run with lazy loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b007132648322876f7255a655df80